### PR TITLE
Improve project initialization

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__init__.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__init__.py
@@ -1,0 +1,6 @@
+import uvloop
+
+from {{cookiecutter.project_slug}}.utils import configure_logging
+
+configure_logging()
+uvloop.install()

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__main__.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__main__.py
@@ -1,11 +1,6 @@
 import sys
 
-import uvloop
-
 from {{cookiecutter.project_slug}}.server import run_app
-from {{cookiecutter.project_slug}}.utils import configure_logging
 
 if __name__ == "__main__":
-    configure_logging()
-    uvloop.install()
     sys.exit(run_app())

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config.py
@@ -5,8 +5,8 @@ __all__ = ("config",)
 
 config = LazySettings(
     MERGE_ENABLED_FOR_DYNACONF=True,
-    ENVVAR_PREFIX_FOR_DYNACONF="PROJECT",
-    ENVVAR_FOR_DYNACONF="PROJECT_SETTINGS_FILE",
+    ENVVAR_PREFIX_FOR_DYNACONF="{{cookiecutter.project_slug.upper()}}",
+    ENVVAR_FOR_DYNACONF="{{cookiecutter.project_slug.upper()}}_SETTINGS_FILE",
     ROOT_PATH_FOR_DYNACONF="/",
     SETTINGS_FILE_FOR_DYNACONF=[
         "default.yml",

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/server/factory.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/server/factory.py
@@ -11,7 +11,7 @@ from {{cookiecutter.project_slug}}.server.registries import (
 __all__ = ("create_app",)
 
 
-def create_app() -> "aiohttp.web.Application":
+async def create_app() -> "aiohttp.web.Application":
     """
     Create and setup the application to run.
     :return: the application instance to run


### PR DESCRIPTION
* Move `uvloop` install at root `__init__.py` project module
* Move logging configuration at root `__init__.py` project module
* Fix `ENVVAR_PREFIX_FOR_DYNACONF` & `ENVVAR_FOR_DYNACONF` `dynaconf` parameters to use `cookiecutter.project_slug.upper()`